### PR TITLE
Fix auto-play toggle and speed upgrade availability

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,10 @@
             isAnimating = true;
 
             playerControls.forEach(btn => btn.disabled = true);
-            Object.values(upgrades).forEach(u => u.element.disabled = true);
+            if (autoPlayInterval) {
+                Object.values(upgrades).forEach(u => u.element.disabled = true);
+                upgrades.autoPlay.element.disabled = false;
+            }
 
             if (gameSpeed >= HIGH_SPEED_THRESHOLD) {
                 showResult(playerChoice, true);
@@ -282,12 +285,18 @@
             
             lucide.createIcons();
             updateUI();
+            if (autoPlayInterval) {
+                Object.values(upgrades).forEach(u => u.element.disabled = true);
+                upgrades.autoPlay.element.disabled = false;
+            }
             
             setTimeout(() => {
                 isAnimating = false;
                 if (!autoPlayInterval) {
                     playerControls.forEach(btn => btn.disabled = false);
                     updateUI();
+                } else {
+                    upgrades.autoPlay.element.disabled = false;
                 }
             }, instant ? 50 : 400);
         }
@@ -329,9 +338,12 @@
                 autoPlayInterval = null;
                 playerControls.forEach(btn => btn.disabled = false);
                 upgrades.autoPlay.element.classList.remove('toggled', 'pulse');
+                updateUI();
             } else {
                 playerControls.forEach(btn => btn.disabled = true);
+                Object.values(upgrades).forEach(u => u.element.disabled = true);
                 upgrades.autoPlay.element.classList.add('toggled', 'pulse');
+                upgrades.autoPlay.element.disabled = false;
                 autoPlayInterval = setInterval(() => playGame(choices[Math.floor(Math.random() * choices.length)]), getIntervalDuration());
             }
         }


### PR DESCRIPTION
## Summary
- enable auto-play button to fully toggle on/off
- keep speed upgrade button available outside of auto-play

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_689e3596a1b4832f852344f8f2fb74c5