### PR TITLE
Keep upgrade buttons active during gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,8 +242,6 @@
             isAnimating = true;
 
             playerControls.forEach(btn => btn.disabled = true);
-            Object.values(upgrades).forEach(u => u.element.disabled = true);
-            upgrades.autoPlay.element.disabled = false;
 
             if (gameSpeed >= HIGH_SPEED_THRESHOLD) {
                 showResult(playerChoice, true);


### PR DESCRIPTION
## Summary
- Restrict in-game disabling to only player choice buttons so upgrades stay clickable during animations.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eca11de64832f844d643e135ad070