### PR TITLE
Add energy resource and manual recharge upgrade

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,10 @@
 
     <!-- Vinst-räknare på vänster sida -->
     <div id="win-tracker" class="absolute top-8 left-4 md:left-8 flex flex-col items-start gap-3"></div>
+    <!-- Energibar -->
+    <div id="energy-bar" class="absolute top-32 left-4 md:left-8 w-4 h-40 bg-slate-300 rounded-full overflow-hidden">
+        <div id="energy-fill" class="w-full h-full bg-emerald-500 transition-all duration-300"></div>
+    </div>
 
     <!-- Huvudcontainer för spelet -->
     <div class="w-full max-w-xs mx-auto p-4 flex flex-col h-screen justify-between">
@@ -73,6 +77,7 @@
                     <button onclick="playGame('paper')" class="btn choice-btn bg-slate-50 p-4 rounded-2xl shadow-md flex justify-center"><i data-lucide="file-text"></i></button>
                     <button onclick="playGame('scissors')" class="btn choice-btn bg-slate-50 p-4 rounded-2xl shadow-md flex justify-center"><i data-lucide="scissors"></i></button>
                 </div>
+                <button id="manualRecharge" onclick="handleUpgradeClick('manualRecharge')" class="hidden btn upgrade-btn bg-slate-50 p-4 rounded-2xl shadow-md"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" onclick="handleUpgradeClick('autoPlay')" class="hidden btn upgrade-btn bg-slate-50 p-4 rounded-2xl shadow-md"><i data-lucide="cog"></i></button>
             </div>
             <div id="player-result" class="h-16 w-full flex flex-col-reverse justify-center items-center text-slate-400"></div>
@@ -116,11 +121,14 @@
         const debugSpeedEl = document.getElementById('debug-speed');
         const dynamicStyles = document.getElementById('dynamic-styles');
         const speedProgressCircle = document.getElementById('speed-progress');
+        const energyFillEl = document.getElementById('energy-fill');
 
         // Spelvariabler
         let isAnimating = false;
         let starBalance = 0;
         let totalWins = 0;
+        let energy = 100;
+        const MAX_ENERGY = 100;
         let autoPlayInterval = null;
         let gameSpeed = 1;
         const BASE_ANIMATION_DURATION = 1.2;
@@ -134,6 +142,16 @@
                 cost: 5, purchased: false, unlocksAt: 5, unlocks: ['speed'],
                 element: document.getElementById('autoPlay'),
                 purchase: function() { this.element.classList.remove('fade-in'); }
+            },
+            manualRecharge: {
+                level: 0, maxLevel: Infinity,
+                cost: () => 1,
+                unlocksAt: 15, unlocks: [],
+                element: document.getElementById('manualRecharge'),
+                purchase: function() {
+                    energy = Math.min(MAX_ENERGY, energy + 10);
+                    this.level++;
+                }
             },
             speed: {
                 level: 0, maxLevel: 100,
@@ -204,11 +222,21 @@
         function updateUI() {
             updateWinVisuals();
 
+            const energyPercent = (energy / MAX_ENERGY) * 100;
+            energyFillEl.style.height = `${energyPercent}%`;
+            if (energy <= 0) {
+                energyFillEl.classList.add('bg-red-500', 'animate-pulse');
+                energyFillEl.classList.remove('bg-emerald-500');
+            } else {
+                energyFillEl.classList.remove('bg-red-500', 'animate-pulse');
+                energyFillEl.classList.add('bg-emerald-500');
+            }
+
             for (const key in upgrades) {
                 const upgrade = upgrades[key];
 
                 const unlockedByWins = upgrade.unlocksAt > 0 && totalWins >= upgrade.unlocksAt;
-                const unlockedByParent = Object.keys(upgrades).some(parentKey => 
+                const unlockedByParent = Object.keys(upgrades).some(parentKey =>
                     upgrades[parentKey].purchased && upgrades[parentKey].unlocks.includes(key)
                 );
                 const shouldBeVisible = unlockedByWins || unlockedByParent;
@@ -221,16 +249,33 @@
                             upgrade.element.disabled = true;
                             upgrade.element.classList.add('purchased');
                         } else {
-                            upgrade.element.disabled = starBalance < upgrade.cost();
+                            if (key === 'manualRecharge') {
+                                upgrade.element.disabled = starBalance < upgrade.cost() || energy >= MAX_ENERGY;
+                            } else {
+                                upgrade.element.disabled = starBalance < upgrade.cost();
+                            }
                         }
-                    } else { 
+                    } else {
                         if (!upgrade.purchased) {
                             upgrade.element.disabled = starBalance < upgrade.cost;
                         }
                     }
                 }
             }
-            
+
+            if (energy <= 0) {
+                playerControls.forEach(btn => btn.disabled = true);
+                if (autoPlayInterval) {
+                    clearInterval(autoPlayInterval);
+                    autoPlayInterval = null;
+                    upgrades.autoPlay.element.classList.remove('toggled', 'pulse');
+                }
+                if (upgrades.autoPlay.purchased) upgrades.autoPlay.element.disabled = true;
+            } else {
+                if (upgrades.autoPlay.purchased && !autoPlayInterval) upgrades.autoPlay.element.disabled = false;
+                if (!autoPlayInterval && !isAnimating) playerControls.forEach(btn => btn.disabled = false);
+            }
+
             const progress = upgrades.speed.level / upgrades.speed.maxLevel;
             const circumference = 100.5;
             const offset = circumference * (1 - progress);
@@ -238,10 +283,19 @@
         }
 
         function playGame(playerChoice) {
-            if (isAnimating) return;
+            if (isAnimating || energy <= 0) return;
             isAnimating = true;
 
+            energy = Math.max(0, energy - 1);
+            updateUI();
+
             playerControls.forEach(btn => btn.disabled = true);
+
+            if (energy <= 0 && autoPlayInterval) {
+                clearInterval(autoPlayInterval);
+                autoPlayInterval = null;
+                upgrades.autoPlay.element.classList.remove('toggled', 'pulse');
+            }
 
             if (gameSpeed >= HIGH_SPEED_THRESHOLD) {
                 showResult(playerChoice, true);
@@ -284,7 +338,7 @@
 
             setTimeout(() => {
                 isAnimating = false;
-                if (!autoPlayInterval) {
+                if (!autoPlayInterval && energy > 0) {
                     playerControls.forEach(btn => btn.disabled = false);
                 }
                 updateUI();
@@ -297,7 +351,8 @@
                 toggleAutoPlay();
                 return;
             }
-            
+            if (key === 'manualRecharge' && energy >= MAX_ENERGY) return;
+
             const currentCost = typeof upgrade.cost === 'function' ? upgrade.cost() : upgrade.cost;
             if (starBalance >= currentCost) {
                 starBalance -= currentCost;
@@ -330,6 +385,7 @@
                 upgrades.autoPlay.element.classList.remove('toggled', 'pulse');
                 updateUI();
             } else {
+                if (energy <= 0) return;
                 playerControls.forEach(btn => btn.disabled = true);
                 upgrades.autoPlay.element.classList.add('toggled', 'pulse');
                 upgrades.autoPlay.element.disabled = false;


### PR DESCRIPTION
## Summary
- Add vertical energy bar UI to track energy
- Introduce energy mechanics: rounds consume energy and game halts at zero
- Add manual recharge upgrade unlocked after 15 wins to convert stars to energy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f33ba02b4832f9d6fba41c0631ffe