### PR TITLE
Rebuild button system and redesign meta board

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,18 @@
             overflow: hidden;
             background-color: #f1f5f9; /* bg-slate-200 */
         }
-        .btn { transition: all 0.2s ease-in-out; pointer-events: auto; cursor: pointer; }
+        .btn {
+            transition: all 0.2s ease-in-out;
+            cursor: pointer;
+            pointer-events: auto;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            height: 100%;
+            position: relative;
+        }
+        .btn:disabled { pointer-events: none; }
         .btn > * { pointer-events: none; }
         .choice-btn:hover:not(:disabled) { transform: translateY(-4px); background-color: #ffffff; }
         .choice-btn:disabled { cursor: not-allowed; opacity: 0.5; }
@@ -34,16 +45,14 @@
         .lucide-crown-xl { width: 40px; height: 40px; }
         .dot { width: 8px; height: 8px; background-color: #cbd5e1; border-radius: 9999px; }
 
-        .win-ring {
-            position: absolute;
-            top: -8px; left: -8px; right: -8px; bottom: -8px;
-            border: 3px solid #334155;
-            border-radius: 9999px;
-            opacity: 0;
-            transform: scale(0.95);
-            transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+        @keyframes winFlash {
+            0%, 100% { transform: scale(1); color: #facc15; }
+            50% { transform: scale(1.3); }
         }
-        .win-ring.visible { opacity: 1; transform: scale(1); }
+        .win-highlight {
+            animation: winFlash 0.6s ease-in-out;
+            color: #facc15;
+        }
 
         .progress-ring-bg { stroke: #e2e8f0; }
         .progress-ring-fg {
@@ -81,15 +90,14 @@
         #player-zone { position: relative; z-index: 10; }
 
         .small-icons .lucide-lg { width: 32px; height: 32px; }
-        .small-icons .win-ring { top: -4px; left: -4px; right: -4px; bottom: -4px; border-width: 2px; }
 
         #meta-board {
-            border: 4px solid #475569;
-            box-shadow: 0 0 20px rgba(71, 85, 105, 0.5);
+            border: 4px solid #000;
+            background-color: #fff;
+            box-shadow: none;
             overflow: hidden;
         }
-        @keyframes meta-pulse { 0%, 100% { border-color: #475569; } 50% { border-color: #0ea5e9; } }
-        .meta-active { animation: meta-pulse 1s infinite; }
+        .meta-active { animation: none; }
         
         #collapse-foam-btn {
             position: relative;
@@ -117,8 +125,8 @@
 <body class="text-slate-800">
 
     <!-- Resurser på vänster sida -->
-    <div class="absolute top-8 left-4 md:left-8 flex flex-col items-start gap-4">
-        <div id="win-tracker" class="flex flex-col items-start gap-3"></div>
+    <div class="absolute top-8 right-4 md:right-8 flex flex-col items-end gap-4">
+        <div id="win-tracker" class="flex flex-col items-end gap-3"></div>
         <div class="flex items-end gap-2">
             <div id="energy-container" class="w-4 h-32 bg-slate-300 rounded-full overflow-hidden p-1 flex flex-col justify-end">
                 <div id="energy-fill" class="w-full bg-emerald-500 rounded-full transition-all duration-300"></div>
@@ -350,16 +358,19 @@ const choices = ['rock', 'paper', 'scissors'];
 const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
 
         function setupButtons() {
-            document.querySelectorAll('[data-choice]').forEach(btn => {
+            document.querySelectorAll('button').forEach(btn => {
                 const choice = btn.dataset.choice;
-                btn.addEventListener('click', () => playGame(choice));
-                btn.addEventListener('mouseenter', () => showTooltip(btn, 'choice'));
-                btn.addEventListener('mouseleave', hideTooltip);
-            });
-            document.querySelectorAll('[data-upgrade]').forEach(btn => {
-                const key = btn.dataset.upgrade;
-                btn.addEventListener('click', () => handleUpgradeClick(key));
-                btn.addEventListener('mouseenter', () => showTooltip(btn, key));
+                const upgrade = btn.dataset.upgrade;
+                if (!choice && !upgrade) return;
+                btn.addEventListener('pointerup', (e) => {
+                    e.preventDefault();
+                    if (choice) playGame(choice);
+                    else handleUpgradeClick(upgrade);
+                });
+                btn.addEventListener('mouseenter', () => {
+                    const key = choice ? 'choice' : upgrade;
+                    if (key) showTooltip(btn, key);
+                });
                 btn.addEventListener('mouseleave', hideTooltip);
             });
         }
@@ -372,11 +383,9 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             board.innerHTML = `
                 <div class="relative h-20 w-20 flex justify-center items-center">
                     <div class="computer-result-icon text-slate-400"></div>
-                    <div class="win-ring computer-ring"></div>
                 </div>
                 <div class="relative h-20 w-20 flex justify-center items-center">
                     <div class="player-result-icon text-slate-400"></div>
-                    <div class="win-ring player-ring"></div>
                 </div>
             `;
             gameBoardContainer.appendChild(board);
@@ -385,9 +394,7 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
                 element: board,
                 isAnimating: false,
                 computerEl: board.querySelector('.computer-result-icon'),
-                playerEl: board.querySelector('.player-result-icon'),
-                computerRing: board.querySelector('.computer-ring'),
-                playerRing: board.querySelector('.player-ring')
+                playerEl: board.querySelector('.player-result-icon')
             });
             adjustBoardLayout();
         }
@@ -417,29 +424,14 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             if (!metaBoard) {
                 metaBoard = document.createElement('div');
                 metaBoard.id = 'meta-board';
-                metaBoard.className = 'bg-white rounded-2xl shadow-lg aspect-square w-full h-auto flex justify-center items-center p-4 transition-all relative';
-                metaBoard.innerHTML = `
-                    <svg width="100%" height="100%" viewBox="0 0 200 200">
-                        <defs>
-                            <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="0%">
-                                <stop offset="0%" style="stop-color:#0ea5e9;stop-opacity:1" />
-                                <stop offset="100%" style="stop-color:#67e8f9;stop-opacity:1" />
-                            </linearGradient>
-                        </defs>
-                        <circle cx="100" cy="100" r="80" stroke="url(#grad1)" stroke-width="4" fill="none">
-                            <animateTransform attributeName="transform" type="rotate" from="0 100 100" to="360 100 100" dur="10s" repeatCount="indefinite" />
-                        </circle>
-                        <circle cx="100" cy="100" r="60" stroke="url(#grad1)" stroke-width="2" fill="none" stroke-dasharray="10 10">
-                             <animateTransform attributeName="transform" type="rotate" from="360 100 100" to="0 100 100" dur="15s" repeatCount="indefinite" />
-                        </circle>
-                    </svg>
-                `;
+                metaBoard.className = 'rounded-2xl aspect-square w-full h-auto flex justify-center items-center';
+                metaBoard.innerHTML = `<i data-lucide="factory" class="lucide-lg text-black"></i>`;
                 gameBoardContainer.innerHTML = '';
                 gameBoardContainer.className = 'flex-grow grid grid-cols-1 items-center justify-center gap-4 max-w-sm mx-auto';
                 gameBoardContainer.appendChild(metaBoard);
             }
             metaBoard.style.display = 'flex';
-            metaBoard.classList.add('meta-active');
+            lucide.createIcons();
             quantumFoamContainer.classList.remove('hidden');
         }
 
@@ -690,8 +682,6 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             consumeEnergy();
             totalGamesPlayed++;
             
-            board.computerRing.classList.remove('visible');
-            board.playerRing.classList.remove('visible');
             choiceButtons.forEach(btn => btn.disabled = true);
 
             if (gameSpeed >= HYPER_SPEED_THRESHOLD && autoPlayInterval) {
@@ -713,16 +703,21 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             board.playerEl.innerHTML = `<div class="${revealClass}"><i data-lucide="${iconMap[playerChoice]}" class="lucide-lg text-slate-800"></i></div>`;
             board.computerEl.innerHTML = `<div class="${revealClass}"><i data-lucide="${iconMap[computerChoice]}" class="lucide-lg text-slate-800"></i></div>`;
 
+            lucide.createIcons();
+
             if (result === 'win') {
                 const starGain = 1 * starMultiplier;
                 starBalance += starGain;
                 totalStarsEarned += starGain;
-                board.playerRing.classList.add('visible');
+                const playerSvg = board.playerEl.querySelector('svg');
+                playerSvg.classList.add('win-highlight');
+                setTimeout(() => playerSvg.classList.remove('win-highlight'), 600);
             } else if (result === 'lose') {
-                board.computerRing.classList.add('visible');
+                const computerSvg = board.computerEl.querySelector('svg');
+                computerSvg.classList.add('win-highlight');
+                setTimeout(() => computerSvg.classList.remove('win-highlight'), 600);
             }
-            
-            lucide.createIcons();
+
             updateUI();
             
             if (!hasEnergy() && autoPlayInterval) stopAutoPlayInterval();
@@ -869,7 +864,6 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
                 gameBoards.forEach(board => {
                     board.computerEl.innerHTML = '';
                     board.playerEl.innerHTML = '';
-                    board.computerRing.classList.remove('visible');
                 });
             }
         }


### PR DESCRIPTION
## Summary
- Refactor button styles and event handling for reliable full-surface clicks
- Move resource and energy bars to fixed right-side layout
- Simplify meta board with stark design and factory icon, and highlight wins with pulsing icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dc54e638832fa2a6527298f1be84