### PR TITLE
Move resource bars to right side to prevent layout shifting

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,9 +124,13 @@
 </head>
 <body class="text-slate-800">
 
-    <!-- Resurser på vänster sida -->
+    <!-- Star display on the left -->
+    <div class="absolute top-8 left-4 md:left-8">
+        <div id="win-tracker" class="flex flex-col items-start gap-3"></div>
+    </div>
+
+    <!-- Resource bars on the right -->
     <div class="absolute top-8 right-4 md:right-8 flex flex-col items-end gap-4">
-        <div id="win-tracker" class="flex flex-col items-end gap-3"></div>
         <div class="flex items-end gap-2">
             <div id="energy-container" class="w-4 h-32 bg-slate-300 rounded-full overflow-hidden p-1 flex flex-col justify-end">
                 <div id="energy-fill" class="w-full bg-emerald-500 rounded-full transition-all duration-300"></div>


### PR DESCRIPTION
## Summary
- Position win tracker on left side
- Anchor energy, reserve energy, and other resource bars to the right side

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4df18c724832f90c70436e5902dd6