### PR TITLE
Implement deterministic RPS logic and bump version to 1.0.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
     
     <div id="tooltip"></div>
 
-    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.1</div>
+    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.2</div>
 
     <script src="roman.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -33,9 +33,8 @@ const tooltip = document.getElementById('tooltip');
         const MAX_ENERGY = 100;
         const MAX_RESERVE_ENERGY = 1500;
         let autoPlayInterval = null;
-        let autoPlayWantsToRun = false; 
+        let autoPlayWantsToRun = false;
         let gameSpeed = 1;
-        let winChance = 1/3;
         let lastTick = performance.now();
         let gameBoards = [];
         let isMetaBoardActive = false;
@@ -81,7 +80,7 @@ const tooltip = document.getElementById('tooltip');
                 cost: 50, purchased: false, unlocksAtGames: 100, unlocks: [],
                 element: document.getElementById('luck'),
                 purchase: function() {
-                    winChance = 0.5;
+                    starMultiplier *= 1.5;
                     this.element.style.display = 'none';
                 }
             },
@@ -287,9 +286,10 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
         
         function getSPS() {
             const boardMultiplier = isMetaBoardActive ? 9 : gameBoards.length;
+            const baseWinRate = 1 / 3;
             const baseSPS = (gameSpeed < HYPER_SPEED_THRESHOLD)
-                ? (1000 / (((1.2 / gameSpeed) * 1000 + 450) / boardMultiplier)) * winChance
-                : (gameSpeed * boardMultiplier) * winChance;
+                ? (1000 / (((1.2 / gameSpeed) * 1000 + 450) / boardMultiplier)) * baseWinRate
+                : (gameSpeed * boardMultiplier) * baseWinRate;
             return baseSPS * starMultiplier;
         }
         
@@ -473,10 +473,15 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
 
         function showResult(playerChoice, board, instant = false) {
             const computerChoice = choices[Math.floor(Math.random() * choices.length)];
-            let result = 'tie';
-            
-            if (Math.random() < winChance) result = 'win';
-            else if (Math.random() < 0.5) result = 'lose';
+            let result;
+
+            if (playerChoice === computerChoice) result = 'draw';
+            else if (
+                (playerChoice === 'rock' && computerChoice === 'scissors') ||
+                (playerChoice === 'scissors' && computerChoice === 'paper') ||
+                (playerChoice === 'paper' && computerChoice === 'rock')
+            ) result = 'win';
+            else result = 'lose';
 
             const revealClass = instant ? '' : 'reveal-item';
             board.playerEl.innerHTML = `<div class="result-wrapper inline-flex justify-center items-center ${revealClass}"><i data-lucide="${iconMap[playerChoice]}" class="lucide-lg text-slate-800"></i></div>`;
@@ -573,7 +578,7 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             consumeEnergy(energyToConsume);
             totalGamesPlayed += energyToConsume;
 
-            const wins = energyToConsume * winChance;
+            const wins = energyToConsume / 3;
             const roundedWins = Math.floor(wins) + (Math.random() < (wins % 1) ? 1 : 0);
             
             const starGain = roundedWins * starMultiplier;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Implement real Rock-Paper-Scissors comparisons in `showResult` and treat ties as draws
- Remove probabilistic win chance in rate calculations and auto-play, switch luck upgrade to boost star multiplier
- Bump application version to 1.0.2

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c01ff24010832fba7caa65e720ee7e