### PR TITLE
Cap crown icons and add multiplier display

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
     
     <div id="tooltip"></div>
 
-    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.2</div>
+    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.3</div>
 
     <script src="roman.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -249,10 +249,19 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             const smallStars = starBalance % 100;
             
             if (crowns > 0) {
-                 const container = document.createElement('div');
-                container.className = 'flex flex-wrap gap-1 items-center';
-                for (let i = 0; i < crowns; i++) container.innerHTML += '<div><i data-lucide="crown" class="lucide-crown-xl text-slate-800"></i></div>';
+                const container = document.createElement('div');
+                container.className = 'grid grid-cols-5 gap-1 items-center';
+                const displayedCrowns = Math.min(crowns, 10);
+                for (let i = 0; i < displayedCrowns; i++) {
+                    container.innerHTML += '<div><i data-lucide="crown" class="lucide-crown-xl text-slate-800"></i></div>';
+                }
                 winTracker.appendChild(container);
+                if (crowns > 10) {
+                    const extraContainer = document.createElement('div');
+                    extraContainer.className = 'flex items-center gap-1 text-slate-800';
+                    extraContainer.innerHTML = `<i data-lucide="crown" class="lucide-crown-xl"></i><span class="text-sm">x ${crowns - 10}</span>`;
+                    winTracker.appendChild(extraContainer);
+                }
             }
             if (gems > 0) {
                 const container = document.createElement('div');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Arrange crowns in a 5-column grid capped at 10 icons
- Show a crown with multiplier when more than 10 crowns
- Bump version to 1.0.3 across UI and package files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02302d924832f90695a6caf9fe668