### PR TITLE
Improve upgrade visuals and progress indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
             <button id="speed" data-upgrade="speed" class="invisible btn upgrade-btn bg-white p-3 rounded-full shadow-lg">
                 <svg class="absolute inset-0 w-full h-full" viewBox="0 0 36 36">
                     <circle class="progress-ring-bg" cx="18" cy="18" r="16" fill="none" stroke-width="3"></circle>
+                    <circle id="speed-early-progress" class="progress-ring-pre" cx="18" cy="18" r="16" fill="none" stroke-width="3" stroke-dasharray="100.5" stroke-dashoffset="100.5"></circle>
                     <circle id="speed-progress" class="progress-ring-fg" cx="18" cy="18" r="16" fill="none" stroke-width="3" stroke-dasharray="100.5" stroke-dashoffset="100.5"></circle>
                 </svg>
                 <i id="speed-icon" data-lucide="chevrons-right" class="relative w-6 h-6 text-slate-600"></i>
@@ -128,7 +129,7 @@
     
     <div id="tooltip"></div>
 
-    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.3</div>
+    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.4</div>
 
     <script src="roman.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@
         const debugGamesPlayedEl = document.getElementById('debug-games-played');
         const dynamicStyles = document.getElementById('dynamic-styles');
         const speedProgressCircle = document.getElementById('speed-progress');
+        const speedEarlyProgressCircle = document.getElementById('speed-early-progress');
         const energyGenProgressCircle = document.getElementById('energy-gen-progress');
         const addBoardProgressCircle = document.getElementById('add-board-progress');
         const downgradeTray = document.getElementById('downgrade-tray');
@@ -263,12 +264,15 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
                     winTracker.appendChild(extraContainer);
                 }
             }
-            if (gems > 0) {
+            const showGemPlaceholders = totalStarsEarned >= 10000;
+            if (gems > 0 || showGemPlaceholders) {
                 const container = document.createElement('div');
                 container.className = 'grid grid-cols-10 gap-1 items-center';
                 const gemSizeClass = gems > 5 ? 'lucide-gem-medium' : 'lucide-gem-large';
-                for (let i = 0; i < gems; i++) {
-                    container.innerHTML += `<div><i data-lucide="gem" class="${gemSizeClass} text-slate-800"></i></div>`;
+                const totalSlots = showGemPlaceholders ? 100 : gems;
+                for (let i = 0; i < totalSlots; i++) {
+                    if (i < gems) container.innerHTML += `<div><i data-lucide="gem" class="${gemSizeClass} text-slate-800"></i></div>`;
+                    else container.innerHTML += '<div class="gem-dot"></div>';
                 }
                 winTracker.appendChild(container);
             }
@@ -285,11 +289,8 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             lucide.createIcons();
 
             winTracker.querySelectorAll('.lucide-star-small').forEach(svg => {
-                const polygon = svg.querySelector('polygon');
-                if (polygon) {
-                    polygon.setAttribute('fill', 'currentColor');
-                    polygon.setAttribute('stroke', 'none');
-                }
+                svg.setAttribute('fill', 'currentColor');
+                svg.setAttribute('stroke', 'none');
             });
         }
         
@@ -410,6 +411,9 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
 
             const speedUpgrade = upgrades.speed;
             speedProgressCircle.style.strokeDashoffset = circumference * (1 - (speedUpgrade.level / speedUpgrade.maxLevel));
+            const earlyFraction = Math.min(speedUpgrade.level, HYPER_SPEED_THRESHOLD) / HYPER_SPEED_THRESHOLD;
+            speedEarlyProgressCircle.style.strokeDashoffset = circumference * (1 - earlyFraction);
+            speedEarlyProgressCircle.style.display = speedUpgrade.level < HYPER_SPEED_THRESHOLD ? 'block' : 'none';
 
             const energyGenUpgrade = upgrades.energyGenerator;
             energyGenProgressCircle.style.strokeDashoffset = circumference * (1 - (energyGenUpgrade.level / energyGenUpgrade.maxLevel));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ body {
     height: 100%;
     position: relative;
 }
-.btn:disabled { pointer-events: none; }
+.btn:disabled { cursor: not-allowed; }
 .btn > * { pointer-events: none; }
 .choice-btn:hover:not(:disabled) { transform: translateY(-4px); background-color: #ffffff; }
 .choice-btn:disabled { cursor: not-allowed; opacity: 0.5; }
@@ -34,6 +34,7 @@ body {
 .lucide-gem-medium { width: 16px; height: 16px; }
 .lucide-crown-xl { width: 40px; height: 40px; }
 .dot { width: 8px; height: 8px; background-color: #cbd5e1; border-radius: 9999px; }
+.gem-dot { width: 16px; height: 16px; background-color: #cbd5e1; border-radius: 9999px; }
 
 @keyframes winFlash {
     0%, 100% { transform: scale(1); color: #facc15; }
@@ -57,6 +58,7 @@ body {
     transform-origin: 50% 50%;
     transition: stroke-dashoffset 0.3s ease;
 }
+.progress-ring-pre { stroke: #94a3b8; transform: rotate(-90deg); transform-origin: 50% 50%; transition: stroke-dashoffset 0.3s ease; }
 
 #tooltip {
     position: absolute;


### PR DESCRIPTION
## Summary
- Allow hover tooltips on disabled buttons
- Add early progress ring for first 10 speed upgrades
- Show filled stars and persistent gem placeholders
- Bump version to 1.0.4

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0299bf484832f9427746ba90eecf5