### PR TITLE
Refine win display and gate resources behind progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     </div>
 
     <!-- Resource bars on the right -->
-    <div class="absolute top-8 right-4 md:right-8 flex flex-col items-end gap-4">
+    <div id="resource-bars" class="hidden absolute top-8 right-4 md:right-8 flex flex-col items-end gap-4">
         <div class="flex items-end gap-2">
             <div id="energy-container" class="w-4 h-32 bg-slate-300 rounded-full overflow-hidden p-1 flex flex-col justify-end">
                 <div id="energy-fill" class="w-full bg-emerald-500 rounded-full transition-all duration-300"></div>
@@ -141,7 +141,7 @@
     
     <div id="tooltip"></div>
 
-    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.4</div>
+    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.5</div>
 
     <script src="roman.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@
         const epsValue = document.getElementById('eps-value');
         const egpsContainer = document.getElementById('egps-container');
         const egpsValue = document.getElementById('egps-value');
+        const resourceBars = document.getElementById('resource-bars');
         const debugTrigger = document.getElementById('debug-trigger');
         const debugMenu = document.getElementById('debug-menu');
         const debugSpeedEl = document.getElementById('debug-speed');
@@ -365,6 +366,7 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             updateRateDisplays();
             updateSellButtons();
             debugGamesPlayedEl.textContent = Math.floor(totalGamesPlayed);
+            resourceBars.classList.toggle('hidden', totalStarsEarned < 10);
 
             const energyPercent = (energy / MAX_ENERGY) * 100;
             energyFillEl.style.height = `${energyPercent}%`;
@@ -576,22 +578,10 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
 
             lucide.createIcons();
 
-            const playerWrapper = board.playerEl.querySelector('.result-wrapper');
-            const computerWrapper = board.computerEl.querySelector('.result-wrapper');
-
             if (result === 'win') {
                 const starGain = 1 * starMultiplier;
                 starBalance += starGain;
                 totalStarsEarned += starGain;
-                playerWrapper.classList.add('winner');
-                const playerSvg = playerWrapper.querySelector('svg');
-                playerSvg.classList.add('win-highlight');
-                setTimeout(() => playerSvg.classList.remove('win-highlight'), 600);
-            } else if (result === 'lose') {
-                computerWrapper.classList.add('winner');
-                const computerSvg = computerWrapper.querySelector('svg');
-                computerSvg.classList.add('win-highlight');
-                setTimeout(() => computerSvg.classList.remove('win-highlight'), 600);
             }
 
             updateUI();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -36,20 +36,6 @@ body {
 .dot { width: 8px; height: 8px; background-color: #cbd5e1; border-radius: 9999px; }
 .gem-dot { width: 16px; height: 16px; background-color: #cbd5e1; border-radius: 9999px; }
 
-@keyframes winFlash {
-    0%, 100% { transform: scale(1); color: #facc15; }
-    50% { transform: scale(1.3); }
-}
-.win-highlight {
-    animation: winFlash 0.6s ease-in-out;
-    color: #facc15;
-}
-
-.winner {
-    border: 4px solid #facc15;
-    border-radius: 9999px;
-    padding: 4px;
-}
 
 .progress-ring-bg { stroke: #e2e8f0; }
 .progress-ring-fg {


### PR DESCRIPTION
## Summary
- Remove win icon bounce and yellow highlight for a cleaner look
- Hide right-side resource bars until the player earns 10 stars
- Bump version to 1.0.5 and update displayed version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02d5c50a4832fb9ec4f1b6aa0b4a1