### PR TITLE
Move menu to lower-left and gate factory unlock

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,12 +110,12 @@
     </div>
 
     <!-- Menu button -->
-    <div id="menu-wrapper" class="fixed bottom-4 right-4">
+    <div id="menu-wrapper" class="fixed bottom-4 left-4">
         <div class="relative">
-            <button id="menu-btn" class="btn w-12 h-12 rounded-full bg-white shadow-lg">
+            <button id="menu-btn" class="btn w-12 h-12 rounded-full bg-white shadow-lg transition-transform hover:scale-110">
                 <i data-lucide="menu" class="w-6 h-6 text-slate-600"></i>
             </button>
-            <div id="menu-dropdown" class="hidden absolute bottom-14 right-0 bg-white rounded-lg shadow-lg">
+            <div id="menu-dropdown" class="hidden absolute bottom-14 left-0 bg-white rounded-lg shadow-lg">
                 <button id="reset-btn" class="block px-4 py-2 text-sm hover:bg-slate-100 whitespace-nowrap">Reset everything</button>
             </div>
         </div>
@@ -141,7 +141,7 @@
     
     <div id="tooltip"></div>
 
-    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.5</div>
+    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.6</div>
 
     <script src="roman.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -112,6 +112,7 @@ const resetBtn = document.getElementById('reset-btn');
             mergeGameBoard: {
                 cost: 1000, purchased: false,
                 element: document.getElementById('mergeGameBoard'),
+                unlockCondition: () => getSPS() >= 300 && getEPS() >= 300,
                 purchase: function() {
                     this.purchased = true;
                     mergeToMetaBoard();
@@ -311,7 +312,12 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
                 : (gameSpeed * boardMultiplier) * baseWinRate;
             return baseSPS * starMultiplier;
         }
-        
+
+        function getEPS() {
+            const boardMultiplier = isMetaBoardActive ? 9 : gameBoards.length;
+            return gameSpeed * boardMultiplier;
+        }
+
         function updateRateDisplays() {
             const sps = getSPS();
             if (sps > 0.1) {
@@ -320,9 +326,8 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             } else {
                 spsContainer.classList.add('hidden');
             }
-            
-            const boardMultiplier = isMetaBoardActive ? 9 : gameBoards.length;
-            const eps = gameSpeed * boardMultiplier;
+
+            const eps = getEPS();
             if (autoPlayInterval) {
                 epsContainer.classList.remove('hidden');
                 epsValue.textContent = eps.toFixed(1);
@@ -393,6 +398,10 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
                                      const parentUnlocked = (parent.level !== undefined && parent.level >= parent.maxLevel) || parent.purchased;
                                      return parent.unlocks && parent.unlocks.includes(key) && parentUnlocked;
                                  });
+
+                if (isUnlocked && typeof upgrade.unlockCondition === 'function') {
+                    isUnlocked = upgrade.unlockCondition();
+                }
 
                 if (isUnlocked) {
                     if (isMetaBoardActive && (key === 'addGameBoard' || key === 'mergeGameBoard')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Reposition hamburger menu to the lower-left and add hover scale effect
- Delay Factory button until both speed and energy per second reach 300 via new unlock condition
- Bump version to 1.0.6

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c034f475a8832f88efed2c1880ebd0