### PR TITLE
fix: improve reset behavior and debug placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,8 +122,8 @@
     </div>
 
     <!-- Debug-meny -->
-    <div id="debug-trigger" class="absolute bottom-0 left-0 w-16 h-16 cursor-pointer"></div>
-        <div id="debug-menu" class="hidden absolute bottom-16 left-4 flex flex-col gap-2 bg-slate-700 p-2 rounded-lg shadow-xl z-20">
+    <div id="debug-trigger" class="absolute top-0 left-0 w-16 h-16 cursor-pointer"></div>
+        <div id="debug-menu" class="hidden absolute top-16 left-4 flex flex-col gap-2 bg-slate-700 p-2 rounded-lg shadow-xl z-20">
         <div class="text-white text-xs font-bold border-b border-slate-600 pb-1 mb-1">Stjärnor</div>
         <button data-add-stars="1" class="text-white text-xs font-bold bg-slate-600 hover:bg-slate-500 rounded px-2 py-1">+1 ★</button>
         <button data-add-stars="100" class="text-white text-xs font-bold bg-slate-600 hover:bg-slate-500 rounded px-2 py-1">+100 ★</button>
@@ -141,7 +141,7 @@
     
     <div id="tooltip"></div>
 
-    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.6</div>
+    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.7</div>
 
     <script src="roman.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -543,14 +543,48 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
                 }
                 const boards = data.gameBoards || 0;
                 for (let i = 0; i < boards; i++) createGameBoard();
+                if (isMetaBoardActive) {
+                    mergeToMetaBoard();
+                }
+                if (upgrades.luck.purchased) {
+                    upgrades.luck.element.style.display = 'none';
+                }
             } catch (e) {
                 console.error('Failed to load save', e);
             }
         }
 
         function resetGame() {
+            stopAutoPlayInterval();
+            autoPlayWantsToRun = false;
             localStorage.removeItem(SAVE_KEY);
-            location.reload();
+            starBalance = 0;
+            totalStarsEarned = 0;
+            totalGamesPlayed = 0;
+            energy = MAX_ENERGY;
+            reserveEnergy = 0;
+            starMultiplier = 1;
+            quantumFoam = 0;
+            gameSpeed = 1;
+            isMetaBoardActive = false;
+            quantumFoamContainer.classList.add('hidden');
+            gameBoards = [];
+            gameBoardContainer.className = 'pointer-events-none flex-grow grid grid-cols-1 items-center justify-center gap-4';
+            gameBoardContainer.innerHTML = '';
+            for (const key in upgrades) {
+                const up = upgrades[key];
+                if (up.level !== undefined) up.level = 0;
+                if (up.purchased !== undefined) up.purchased = false;
+                up.element.classList.remove('purchased', 'invisible', 'toggled', 'pulse');
+                up.element.disabled = false;
+                up.element.style.display = '';
+            }
+            createGameBoard();
+            choiceButtons.forEach(btn => btn.disabled = false);
+            menuDropdown.classList.add('hidden');
+            updateAnimationSpeed();
+            manageAutoPlay();
+            updateUI();
         }
 
         async function playGame(playerChoice, board = gameBoards[0]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Move debug button to the top-left corner
- Reset menu now clears game state instead of reloading
- Keep luck upgrade hidden after reload and bump version to 1.0.7

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0395e0dc0832fbe47ea33095a5975