### PR TITLE
Restore winner circle

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     
     <div id="tooltip"></div>
 
-    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.7</div>
+    <div id="version-info" class="absolute bottom-1 left-1 text-[10px] text-slate-400 select-none">v1.0.8</div>
 
     <script src="roman.js"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -616,8 +616,8 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
             else result = 'lose';
 
             const revealClass = instant ? '' : 'reveal-item';
-            board.playerEl.innerHTML = `<div class="result-wrapper inline-flex justify-center items-center ${revealClass}"><i data-lucide="${iconMap[playerChoice]}" class="lucide-lg text-slate-800"></i></div>`;
-            board.computerEl.innerHTML = `<div class="result-wrapper inline-flex justify-center items-center ${revealClass}"><i data-lucide="${iconMap[computerChoice]}" class="lucide-lg text-slate-800"></i></div>`;
+            board.playerEl.innerHTML = `<div class="result-wrapper inline-flex justify-center items-center ${revealClass} ${result === 'win' ? 'winner' : ''}"><i data-lucide="${iconMap[playerChoice]}" class="lucide-lg text-slate-800"></i></div>`;
+            board.computerEl.innerHTML = `<div class="result-wrapper inline-flex justify-center items-center ${revealClass} ${result === 'lose' ? 'winner' : ''}"><i data-lucide="${iconMap[computerChoice]}" class="lucide-lg text-slate-800"></i></div>`;
 
             lucide.createIcons();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -75,6 +75,16 @@ body {
 
 .small-icons .lucide-lg { width: 32px; height: 32px; }
 
+.result-wrapper.winner {
+    border: 4px solid #475569;
+    border-radius: 9999px;
+    padding: 8px;
+}
+
+.small-icons .result-wrapper.winner {
+    padding: 4px;
+}
+
 #meta-board {
     border: 4px solid #000;
     background-color: #fff;


### PR DESCRIPTION
## Summary
- Highlight winning icons with a ring
- Bump version to 1.0.8 and show updated UI version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c03d898764832fb9c0eac490a632ca