### PR TITLE
Optimize icon rendering and bump version

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.2.1</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.2.2</div>
         </footer>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/phase1/index.js
+++ b/src/phase1/index.js
@@ -159,6 +159,7 @@ const gemLargeTemplate = buildIcon('gem', 'lucide-gem-large text-slate-800');
 const gemMediumTemplate = buildIcon('gem', 'lucide-gem-medium text-slate-800');
 const starSmallTemplate = buildIcon('star', 'lucide-star-small text-slate-800');
 const minusTemplate = buildIcon('minus', 'relative w-6 h-6 text-red-500');
+const factoryTemplate = buildIcon('factory', 'lucide-lg text-black');
 
         function setupButtons() {
             document.querySelectorAll('button').forEach(btn => {
@@ -237,13 +238,12 @@ const minusTemplate = buildIcon('minus', 'relative w-6 h-6 text-red-500');
                 metaBoard = document.createElement('div');
                 metaBoard.id = 'meta-board';
                 metaBoard.className = 'rounded-2xl aspect-square w-full h-auto flex justify-center items-center';
-                metaBoard.innerHTML = `<i data-lucide="factory" class="lucide-lg text-black"></i>`;
+                metaBoard.appendChild(factoryTemplate.cloneNode(true));
                 gameBoardContainer.innerHTML = '';
                 gameBoardContainer.className = 'flex-grow grid grid-cols-1 items-center justify-center gap-4 max-w-sm mx-auto';
                 gameBoardContainer.appendChild(metaBoard);
             }
             metaBoard.style.display = 'flex';
-            lucide.createIcons({}, metaBoard);
             quantumFoamContainer.classList.remove('hidden');
         }
 


### PR DESCRIPTION
## Summary
- cache pre-generated SVG icons and reuse DOM nodes instead of calling `lucide.createIcons` repeatedly
- simplify tooltip star cost rendering with prebuilt SVG
- bump app version to 1.2.1 in code and UI

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c07efe07e8832f9177e5a3dcb324d4