### PR TITLE
Fix missing enemy icons and bump version

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.1</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.2</div>
         </footer>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/phase1/index.js
+++ b/src/phase1/index.js
@@ -140,14 +140,7 @@ const gemMediumTemplate = buildIcon('gem', 'lucide-gem-medium text-slate-800');
 const starSmallTemplate = buildIcon('star', 'lucide-star-small text-slate-800');
 const minusTemplate = buildIcon('minus', 'relative w-6 h-6 text-red-500');
 
-const iconCache = {};
-const getIcon = (name, className = '') => {
-    const key = `${name}:${className}`;
-    if (!iconCache[key]) {
-        iconCache[key] = buildIcon(name, className);
-    }
-    return iconCache[key].cloneNode(true);
-};
+const getIcon = (name, className = '') => buildIcon(name, className);
 
 let uiUpdatePending = false;
 function scheduleUIUpdate() {


### PR DESCRIPTION
## Summary
- fix enemy icon rendering by rebuilding icons without caching
- bump version to v1.3.2

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c13511fc832f9f9e2e7048aea4f4