### PR TITLE
Fix game board initialization and bump version

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.3</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.4</div>
         </footer>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -1,7 +1,9 @@
 import { phases, setPhase } from './src/gamePhase.js';
 import { preloadIcons, replaceIcons } from './src/icons.js';
 
-await preloadIcons();
-replaceIcons();
+// Load icons without blocking game initialization
+preloadIcons()
+  .then(() => replaceIcons())
+  .catch(err => console.error('Failed to preload icons', err));
 
 setPhase(phases.INDUSTRY);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Load icons asynchronously to avoid blocking game board creation
- Bump app version to 1.3.4

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2ca68fe38832fa910b609ec021e74