### PR TITLE
fix: show factory when speed and energy capped

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.5</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.6</div>
         </footer>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.3",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.3.3",
+      "version": "1.3.6",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/phase1/index.js
+++ b/src/phase1/index.js
@@ -118,7 +118,10 @@ const resetBtn = document.getElementById('reset-btn');
                 cost: 1000, purchased: false,
                 unlocksAt: 0,
                 element: document.getElementById('mergeGameBoard'),
-                unlockCondition: () => getSPS() >= 300 && getEPS() >= 300,
+                // Factory becomes available when both speed and energy
+                // production are 500/s or more, or stars/s exceeds 250.
+                unlockCondition: () =>
+                    ((getEPS() >= 500 && upgrades.energyGenerator.level * 5 >= 500) || getSPS() >= 250),
                 purchase: function() {
                     this.purchased = true;
                     mergeToMetaBoard();
@@ -401,6 +404,9 @@ function scheduleUIUpdate() {
 
         function updateSellButtons() {
             downgradeTray.innerHTML = '';
+            const factoryReady = upgrades.mergeGameBoard.unlockCondition &&
+                upgrades.mergeGameBoard.unlockCondition();
+            if (factoryReady && !upgrades.mergeGameBoard.purchased) return;
             if (upgrades.energyGenerator.level < upgrades.energyGenerator.maxLevel) return;
 
             const sellableUpgrades = ['speed', 'addGameBoard'];
@@ -439,8 +445,16 @@ function scheduleUIUpdate() {
         }
 
         function updateUpgrades() {
+            const factoryReady = upgrades.mergeGameBoard.unlockCondition &&
+                upgrades.mergeGameBoard.unlockCondition() &&
+                !upgrades.mergeGameBoard.purchased;
             for (const key in upgrades) {
                 const upgrade = upgrades[key];
+
+                if (factoryReady && key !== 'mergeGameBoard') {
+                    upgrade.element.classList.add('invisible');
+                    continue;
+                }
 
                 let isUnlocked = (upgrade.unlocksAt === 0) ||
                                  (upgrade.unlocksAt > 0 && totalStarsEarned >= upgrade.unlocksAt) ||


### PR DESCRIPTION
## Summary
- show only the factory upgrade once speed and energy hit 500/s or SPS exceeds 250
- hide sell buttons when factory is available
- bump app version to 1.3.6

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2daaa2098832f913f5cd0c29528b3