### PR TITLE
feat: add fast star counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,13 @@
 
     <!-- Star display on the left -->
     <div class="absolute top-8 left-4 md:left-8">
-        <div id="win-tracker" class="flex flex-col items-start gap-3"></div>
+        <div id="star-counter" class="flex items-center gap-2">
+            <i data-lucide="star" class="w-8 h-8 text-yellow-500 fill-yellow-500"></i>
+            <div class="leading-none">
+                <div id="star-balance" class="text-3xl font-bold font-mono">0</div>
+                <div id="star-rate" class="text-green-600 font-bold font-mono text-sm">+0/s</div>
+            </div>
+        </div>
     </div>
 
     <!-- Resource bars on the right -->
@@ -73,12 +79,12 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.6</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.7</div>
         </footer>
     </div>
 
-    <!-- Uppgraderingsknappar -->
-    <div class="absolute bottom-8 right-8 flex items-end gap-3">
+    <!-- Uppgraderingsknappar (dolda i steg 2) -->
+    <div class="absolute bottom-8 right-8 flex items-end gap-3 hidden">
         <div id="downgrade-tray" class="flex flex-col gap-3"></div>
         <div id="upgrade-tray" class="flex flex-col gap-3">
             <button id="speed" data-upgrade="speed" class="invisible btn upgrade-btn bg-white p-3 rounded-full shadow-lg">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/phase1/index.js
+++ b/src/phase1/index.js
@@ -3,7 +3,8 @@ import { getIcon } from "../icons.js";
         // DOM-element
         const gameBoardContainer = document.getElementById('game-board-container');
         const choiceButtons = document.querySelectorAll('#player-controls-container .choice-btn');
-        const winTracker = document.getElementById('win-tracker');
+        const starBalanceEl = document.getElementById('star-balance');
+        const starRateEl = document.getElementById('star-rate');
         const energyFillEl = document.getElementById('energy-fill');
         const reserveEnergyFillEl = document.getElementById('reserve-energy-fill');
         const quantumFoamContainer = document.getElementById('quantum-foam-container');
@@ -45,8 +46,6 @@ const resetBtn = document.getElementById('reset-btn');
         let lastTick = performance.now();
         let lastUIRender = performance.now();
         let passiveInterval = null;
-        let lastStarBalance = -1;
-        let lastTotalStarsEarned = -1;
         let gameBoards = [];
         let isMetaBoardActive = false;
         let starMultiplier = 1;
@@ -134,10 +133,6 @@ const iconMap = { rock: 'gem', paper: 'file-text', scissors: 'scissors' };
 
 const buildIcon = (name, className = '') => getIcon(name, className);
 
-const crownTemplate = buildIcon('crown', 'lucide-crown-xl text-slate-800');
-const gemLargeTemplate = buildIcon('gem', 'lucide-gem-large text-slate-800');
-const gemMediumTemplate = buildIcon('gem', 'lucide-gem-medium text-slate-800');
-const starSmallTemplate = buildIcon('star', 'lucide-star-small text-slate-800');
 const minusTemplate = buildIcon('minus', 'relative w-6 h-6 text-red-500');
 
 
@@ -290,80 +285,20 @@ function scheduleUIUpdate() {
             if (autoPlayInterval) restartAutoPlay();
         }
 
-        function getVisibleDots() {
-            if (totalStarsEarned >= 30) return 100;
-            if (totalStarsEarned >= 10) return 20;
-            if (totalStarsEarned >= 5) return 10;
-            return 5;
+        let displayedStars = 0;
+
+        function updateStarDisplay() {
+            const diff = starBalance - displayedStars;
+            if (diff > 0) {
+                displayedStars += Math.max(1, Math.floor(diff / 5));
+            } else {
+                displayedStars = starBalance;
+            }
+            starBalanceEl.textContent = Math.floor(displayedStars).toLocaleString('sv-SE');
+            starRateEl.textContent = `+${Math.floor(getSPS()).toLocaleString('sv-SE')}/s`;
         }
 
-        function updateWinVisuals() {
-            if (starBalance === lastStarBalance && totalStarsEarned === lastTotalStarsEarned) return;
-            lastStarBalance = starBalance;
-            lastTotalStarsEarned = totalStarsEarned;
-
-            winTracker.innerHTML = '';
-            const crowns = Math.floor(starBalance / 10000);
-            const gems = Math.floor((starBalance % 10000) / 100);
-            const smallStars = starBalance % 100;
-
-            if (crowns > 0) {
-                const container = document.createElement('div');
-                container.className = 'grid grid-cols-5 gap-1 items-center';
-                const displayedCrowns = Math.min(crowns, 10);
-                for (let i = 0; i < displayedCrowns; i++) {
-                    const wrap = document.createElement('div');
-                    wrap.appendChild(crownTemplate.cloneNode(true));
-                    container.appendChild(wrap);
-                }
-                winTracker.appendChild(container);
-                if (crowns > 10) {
-                    const extra = document.createElement('div');
-                    extra.className = 'flex items-center gap-1 text-slate-800';
-                    extra.appendChild(crownTemplate.cloneNode(true));
-                    const span = document.createElement('span');
-                    span.className = 'text-sm';
-                    span.textContent = `x ${crowns - 10}`;
-                    extra.appendChild(span);
-                    winTracker.appendChild(extra);
-                }
-            }
-
-            const showGemPlaceholders = totalStarsEarned >= 10000;
-            if (gems > 0 || showGemPlaceholders) {
-                const container = document.createElement('div');
-                container.className = 'grid grid-cols-10 gap-1 items-center';
-                const gemTemplate = gems > 5 ? gemMediumTemplate : gemLargeTemplate;
-                const totalSlots = showGemPlaceholders ? 100 : gems;
-                for (let i = 0; i < totalSlots; i++) {
-                    const slot = document.createElement('div');
-                    if (i < gems) {
-                        slot.appendChild(gemTemplate.cloneNode(true));
-                    } else {
-                        slot.className = 'gem-dot';
-                    }
-                    container.appendChild(slot);
-                }
-                winTracker.appendChild(container);
-            }
-
-            const dotsToShow = getVisibleDots();
-            const gridContainer = document.createElement('div');
-            gridContainer.className = 'grid grid-cols-10 gap-1';
-            for (let i = 0; i < dotsToShow; i++) {
-                const slot = document.createElement('div');
-                if (i < smallStars) {
-                    const star = starSmallTemplate.cloneNode(true);
-                    star.setAttribute('fill', 'currentColor');
-                    star.setAttribute('stroke', 'none');
-                    slot.appendChild(star);
-                } else {
-                    slot.className = 'dot';
-                }
-                gridContainer.appendChild(slot);
-            }
-            winTracker.appendChild(gridContainer);
-        }
+        setInterval(updateStarDisplay, 50);
         
         function getSPS() {
             const boardMultiplier = isMetaBoardActive ? 9 : gameBoards.length;
@@ -574,7 +509,7 @@ const uiState = {
 
             if (!tasks.length) return;
 
-            tasks.push(updateWinVisuals);
+            tasks.push(updateStarDisplay);
             tasks.push(saveGame);
             tasks.forEach(fn => fn());
 


### PR DESCRIPTION
## Summary
- replace star tally with live counter showing total stars and gain per second
- hide legacy upgrade controls for step 2
- bump version to 1.3.7

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2de79c878832facef7c67e5829d99