### PR TITLE
fix: align countdown and unlock upgrades

### DIFF
--- a/city.html
+++ b/city.html
@@ -670,6 +670,6 @@
         }
         initialize();
     </script>
-    <div id="version-info" class="fixed bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.8</div>
+    <div id="version-info" class="fixed bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.9</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.8</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.9</div>
         </footer>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.6",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.3.6",
+      "version": "1.3.9",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/phase1/index.js
+++ b/src/phase1/index.js
@@ -392,6 +392,7 @@ function scheduleUIUpdate() {
             const factoryReady = upgrades.mergeGameBoard.unlockCondition &&
                 upgrades.mergeGameBoard.unlockCondition() &&
                 !upgrades.mergeGameBoard.purchased;
+            const progressionStars = Math.max(starBalance, totalStarsEarned);
             for (const key in upgrades) {
                 const upgrade = upgrades[key];
 
@@ -406,7 +407,7 @@ function scheduleUIUpdate() {
                 }
 
                 let isUnlocked = (upgrade.unlocksAt === 0) ||
-                                 (upgrade.unlocksAt > 0 && totalStarsEarned >= upgrade.unlocksAt) ||
+                                 (upgrade.unlocksAt > 0 && progressionStars >= upgrade.unlocksAt) ||
                                  (upgrade.unlocksAtGames > 0 && totalGamesPlayed >= upgrade.unlocksAtGames) ||
                                  (upgrade.unlocksAtSPS > 0 && getSPS() >= upgrade.unlocksAtSPS) ||
                                  Object.keys(upgrades).some(parentKey => {
@@ -563,6 +564,8 @@ const uiState = {
                 const wrapper = document.createElement('div');
                 wrapper.innerHTML = svgMap[icon];
                 const svg = wrapper.firstElementChild;
+                svg.style.width = '100%';
+                svg.style.height = '100%';
                 svg.style.animationDuration = `${duration}ms`;
                 svg.style.animationDelay = `${duration * index}ms`;
                 svg.classList.add('countdown-frame');

--- a/style.css
+++ b/style.css
@@ -70,7 +70,16 @@ body {
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .7; } }
 .pulse { animation: pulse 1s infinite cubic-bezier(0.4, 0, 0.6, 1); }
 .countdown-pop { animation-name: pop; animation-timing-function: ease-in-out; }
-.countdown-container { position: relative; }
+.countdown-container {
+    position: relative;
+    width: 56px;
+    height: 56px;
+}
+
+.small-icons .countdown-container {
+    width: 32px;
+    height: 32px;
+}
 .countdown-frame { position: absolute; top: 0; left: 0; opacity: 0; animation-name: countdownFade; animation-fill-mode: forwards; }
 @keyframes countdownFade { from { opacity: 1; } to { opacity: 0; } }
 


### PR DESCRIPTION
## Summary
- center countdown numerals so rock, paper, scissors icons align
- unlock upgrades based on highest star count to avoid stalled progress
- bump version to 1.3.9 across project

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3bcfc5dd0832f8b8226cbb67da9ae