### PR TITLE
Add bank upgrade to trigger city phase and store stars

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.6</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.7</div>
         </footer>
     </div>
 
@@ -106,6 +106,7 @@
                 <i data-lucide="copy" class="relative w-6 h-6 text-slate-600"></i>
             </button>
             <button id="mergeGameBoard" data-upgrade="mergeGameBoard" class="invisible btn upgrade-btn bg-white p-3 rounded-full shadow-lg"><i data-lucide="factory" class="relative w-6 h-6 text-slate-600"></i></button>
+            <button id="bank" data-upgrade="bank" class="invisible btn upgrade-btn bg-white p-3 rounded-full shadow-lg"><i data-lucide="wallet" class="relative w-6 h-6 text-slate-600"></i></button>
         </div>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/gamePhase.js
+++ b/src/gamePhase.js
@@ -16,6 +16,9 @@ export async function setPhase(phase) {
       currentModule = await import('./phase1/index.js');
       return currentModule.init();
     case phases.CITY:
+      window.location.href = 'stage-2.html';
+      currentModule = null;
+      return;
     case phases.WAR:
     case phases.ESCAPE:
     default:

--- a/src/phase1/index.js
+++ b/src/phase1/index.js
@@ -1,4 +1,5 @@
 import { getIcon } from "../icons.js";
+import { phases, setPhase } from "../gamePhase.js";
 
         // DOM-element
         const gameBoardContainer = document.getElementById('game-board-container');
@@ -125,6 +126,22 @@ const resetBtn = document.getElementById('reset-btn');
                 purchase: function() {
                     this.purchased = true;
                     mergeToMetaBoard();
+                    for (const key in upgrades) {
+                        if (key !== 'bank') {
+                            upgrades[key].element.classList.add('hidden');
+                        }
+                    }
+                }
+            },
+            bank: {
+                cost: 0,
+                purchased: false,
+                unlocksAt: 0,
+                element: document.getElementById('bank'),
+                unlockCondition: () => upgrades.mergeGameBoard.purchased,
+                purchase: function() {
+                    localStorage.setItem('rpi-stars', String(starBalance));
+                    setPhase(phases.CITY);
                 }
             }
         };

--- a/stage-2.html
+++ b/stage-2.html
@@ -704,6 +704,7 @@
         }
         initialize();
     </script>
+    <div id="version-info" class="absolute bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.7</div>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- add Bank upgrade unlocked after mergeGameBoard and hide other upgrades when active
- store star balance and jump to City phase when Bank is purchased
- bump version to v1.3.7 and display on both stages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c50b175c90832fb72638380d895178