### PR TITLE
feat: load stars from storage for stage 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.7</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.8</div>
         </footer>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/phase2/index.js
+++ b/src/phase2/index.js
@@ -1,0 +1,7 @@
+// Stage 2 initialization logic
+export function init(gameState) {
+  const storedStars = localStorage.getItem('rpi-stars');
+  const parsed = storedStars !== null ? Number.parseInt(storedStars, 10) : NaN;
+  gameState.stars = Number.isNaN(parsed) ? 0 : parsed;
+  localStorage.removeItem('rpi-stars');
+}

--- a/stage-2.html
+++ b/stage-2.html
@@ -250,7 +250,7 @@
 
         // --- GAME STATE ---
         const gameState = {
-            stars: 10000,
+            stars: 0, // will be populated from localStorage
             science: 0,
             population: 0,
             populationAllocation: 0.5, // 0 = 100% stars, 1 = 100% science
@@ -265,6 +265,8 @@
             megastructureResearched: false,
             landExpanded: false,
         };
+
+        const phase2Init = import('./src/phase2/index.js').then(({ init }) => init(gameState));
         
         const buildingData = {
             home: { cost: 10000, capacity: 10 },
@@ -702,9 +704,9 @@
             setInterval(logicTick, 1000);
             setInterval(fastUiTick, 50);
         }
-        initialize();
+          phase2Init.then(initialize);
     </script>
-    <div id="version-info" class="absolute bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.7</div>
+    <div id="version-info" class="absolute bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.8</div>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- initialize Stage 2 with stars from localStorage, clearing the stored value afterward
- load Stage 2 initialization module dynamically
- bump version to v1.3.8 and update displayed version numbers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c50c39317c832f95a3b049bdf1ecc5