### PR TITLE
chore: centralize version and bump to v1.3.7

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.9</div>
+            <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.7</div>
         </footer>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -1,9 +1,12 @@
 import { phases, setPhase } from './src/gamePhase.js';
 import { preloadIcons, replaceIcons } from './src/icons.js';
+import { VERSION } from './src/version.js';
 
 // Load icons without blocking game initialization
 preloadIcons()
   .then(() => replaceIcons())
   .catch(err => console.error('Failed to preload icons', err));
+
+document.getElementById('version-info').textContent = VERSION;
 
 setPhase(phases.INDUSTRY);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.9",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-paper-infinity",
-      "version": "1.3.9",
+      "version": "1.3.7",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.9",
+  "version": "1.3.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,1 @@
+export const VERSION = 'v1.3.7';

--- a/stage-2.html
+++ b/stage-2.html
@@ -245,11 +245,14 @@
         </div>
     </div>
 
+    <div id="version-info" class="absolute bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.7</div>
     <script type="module">
       import { init } from './src/phase2/index.js';
+      import { VERSION } from './src/version.js';
+
       init();
+      document.getElementById('version-info').textContent = VERSION;
     </script>
-    <div id="version-info" class="absolute bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.9</div>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- bump app version to v1.3.7
- show version label in both stages using shared module

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5107750d8832fba879455db37f437