### PR TITLE
Fix crown icon preload race

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,11 +2,17 @@ import { phases, setPhase } from './src/gamePhase.js';
 import { preloadIcons, replaceIcons } from './src/icons.js';
 import { VERSION } from './src/version.js';
 
-// Load icons without blocking game initialization
-preloadIcons()
-  .then(() => replaceIcons())
-  .catch(err => console.error('Failed to preload icons', err));
-
 document.getElementById('version-info').textContent = VERSION;
 
-setPhase(phases.INDUSTRY);
+async function bootstrap() {
+  try {
+    await preloadIcons();
+    replaceIcons();
+  } catch (err) {
+    console.error('Failed to preload icons', err);
+  }
+
+  await setPhase(phases.INDUSTRY);
+}
+
+bootstrap();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const VERSION = 'v1.3.9';
+export const VERSION = 'v1.3.10';


### PR DESCRIPTION
## Summary
- wait for icon preloading to finish before bootstrapping the gameplay phase so SVG templates like the crown render correctly
- update the displayed version number to v1.3.10 and keep package metadata in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd40d97fb4832fac4cc9d0f7ba5604