### PR TITLE
Fix bank icon preload and stage transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                 <button id="manualRecharge" data-upgrade="manualRecharge" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="battery-charging"></i></button>
                 <button id="autoPlay" data-upgrade="autoPlay" class="invisible btn upgrade-btn bg-slate-50 w-16 h-16 rounded-full shadow-md flex justify-center items-center"><i data-lucide="repeat-2"></i></button>
             </div>
-              <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.8</div>
+              <div id="version-info" class="text-[10px] text-slate-400 select-none self-start">v1.3.11</div>
         </footer>
     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-paper-infinity",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/gamePhase.js
+++ b/src/gamePhase.js
@@ -13,9 +13,19 @@ export async function setPhase(phase) {
   }
   switch (phase) {
     case phases.INDUSTRY:
+      if (!document.getElementById('game-board-container')) {
+        window.location.href = './index.html';
+        currentModule = null;
+        return;
+      }
       currentModule = await import('./phase1/index.js');
       return currentModule.init();
     case phases.CITY:
+      if (!document.getElementById('land-grid')) {
+        window.location.href = './stage-2.html';
+        currentModule = null;
+        return;
+      }
       currentModule = await import('./phase2/index.js');
       return currentModule.init();
     case phases.WAR:

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,7 +1,7 @@
 const ICONS = [
   'zap', 'star', 'timer', 'zap-off', 'atom', 'gem', 'file-text', 'scissors',
   'battery-charging', 'repeat-2', 'chevrons-right', 'battery-plus',
-  'clover', 'copy', 'menu', 'factory', 'crown', 'minus'
+  'clover', 'copy', 'menu', 'factory', 'crown', 'minus', 'wallet'
 ];
 
 const cache = {};

--- a/src/version.js
+++ b/src/version.js
@@ -1,1 +1,1 @@
-export const VERSION = 'v1.3.10';
+export const VERSION = 'v1.3.11';

--- a/stage-2.html
+++ b/stage-2.html
@@ -247,7 +247,7 @@
         </div>
     </div>
 
-      <div id="version-info" class="absolute bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.8</div>
+      <div id="version-info" class="absolute bottom-2 left-2 text-[10px] text-slate-400 select-none">v1.3.11</div>
       <!-- Menu button -->
       <div id="menu-wrapper" class="fixed bottom-4 left-4">
           <div class="relative">


### PR DESCRIPTION
## Summary
- preload the wallet icon so the Bank button renders correctly
- safeguard phase transitions by redirecting to the appropriate page when Stage 2 UI is missing
- bump the displayed and package version numbers to v1.3.11

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb98468d8832fb0d79fb937eb9ba5